### PR TITLE
vulnerable dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
 
     // This dependency is used by the application.
     implementation("com.google.guava:guava:31.1-jre")
+
+    implementation("org.apache.logging.log4j:log4j-core:2.12.0")
 }
 
 // Apply a specific Java toolchain to ease working on different environments.


### PR DESCRIPTION
Purposefully adding a vulnerable dependency.  On merge, Dependabot is unlikely (at this time of PR) raise a Security Alert as only version updates are supported.

This will follow up with a dependency submission on PR/push to see if the alert and/or security update is provided.