### PR TITLE
Remove the need for contents: write permission

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: build
 
 on:
   push:
@@ -7,10 +7,8 @@ on:
   pull_request:
 
 jobs:
-  gradle:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
@@ -21,21 +19,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          dependency-graph: generate-and-submit
+          dependency-graph: generate
 
       - name: Execute Gradle build
         run: ./gradlew build
-
-  review:
-    if: github.event_name == 'pull_request'
-    needs: gradle
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: 'Checkout Repository'
-        uses: actions/checkout@v4
-      - name: 'Dependency Review'
-        uses: actions/dependency-review-action@v3
-        with:
-          comment-summary-in-pr: true

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,22 @@
+name: review
+
+on:
+  pull_request:
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@v4
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@v3
+        with:
+          retry-on-snapshot-warnings: true
+          retry-on-snapshot-warnings-timeout: 600
+          comment-summary-in-pr: 'on-failure'
+          license-check: false
+          fail-on-severity: 'high'

--- a/.github/workflows/submit-sbom.yml
+++ b/.github/workflows/submit-sbom.yml
@@ -1,8 +1,9 @@
 name: submit-sbom
 
 on:
-  workflow_run: ['build']
-  types: [completed]
+  workflow_run: 
+    workflows: [build]
+    types: [completed]
 
 jobs:
   submit-dependency-graph:

--- a/.github/workflows/submit-sbom.yml
+++ b/.github/workflows/submit-sbom.yml
@@ -1,0 +1,14 @@
+name: submit-sbom
+
+on:
+  workflow_run: ['build']
+  types: [completed]
+
+jobs:
+  submit-dependency-graph:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Retrieve dependency graph artifact and submit
+      uses: gradle/gradle-build-action@v2
+      with:
+        dependency-graph: download-and-submit


### PR DESCRIPTION
* Removes direct dependency on the build step for the review action, which will now sit in a retry loop
* Submitting the SBOM is triggered after the build workflow completes

This setup removes the need for `contents: write` permission.